### PR TITLE
Iteration 2: Retries and callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-debug.log*
 
 .env
 .ngrok_host
+.vscode

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -1,20 +1,24 @@
 # frozen_string_literal: true
-class Api::V1::NotificationsController < ActionController::API
-  def create
-    HandleNotificationRequestService.process(
-      number: notification_params[:number],
-      message: notification_params[:message]
-    )
+module Api
+  module V1
+    class NotificationsController < ActionController::API
+      def create
+        HandleNotificationRequestService.process(
+          number: notification_params[:number],
+          message: notification_params[:message]
+        )
 
-    render json: {
-      number: notification_params[:number],
-      message: notification_params[:message]
-    }, status: :accepted
-  end
+        render json: {
+          number: notification_params[:number],
+          message: notification_params[:message]
+        }, status: :accepted
+      end
 
-  private
+      private
 
-  def notification_params
-    params.require(:notification).permit(:number, :message)
+      def notification_params
+        params.require(:notification).permit(:number, :message)
+      end
+    end
   end
 end

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
-class CallbacksController < ApplicationController
-  def text
+class CallbacksController < ActionController::API
+  def text_message
+    Notification.find_by(external_id: callback_params[:message_id]).update(status: callback_params[:status])
+
+    render json: {
+      number: callback_params[:status],
+      message: callback_params[:message_id]
+    }, status: :accepted
+  end
+
+  private
+
+  def callback_params
+    params.require(:callback).permit(:status, :message_id)
   end
 end

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 class CallbacksController < ActionController::API
   def text_message
+    HandleCallbackService.process(
+      external_id: callback_params[:message_id],
+      status: callback_params[:status]
+    )
+
     Notification.find_by(external_id: callback_params[:message_id]).update(status: callback_params[:status])
 
     render json: {

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -10,7 +10,9 @@ class Notification < ApplicationRecord
   validates :provider_url, presence: true
   validates :status, inclusion: { in: %w[created queued invalid delivered failed] }
 
-  # direct in the sense that provider is shared
+  RETRY_LIMIT = 2
+
+  # direct means shared provider_url
   def direct_parent_count
     return 0 unless parent.present?
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -2,6 +2,14 @@ class Notification < ApplicationRecord
   has_one :child, class_name: 'Notification', foreign_key: 'notification_id'
   belongs_to :parent, class_name: 'Notification', foreign_key: 'notification_id', optional: true
 
+  validates :number, presence: true,
+                     numericality: true,
+                     length: { minimum: 10, maximum: 10 }
+
+  validates :message, presence: true
+  validates :provider_url, presence: true
+  validates :status, inclusion: { in: %w[created queued invalid delivered failed] }
+
   # direct in the sense that provider is shared
   def direct_parent_count
     return 0 unless parent.present?

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,4 +1,15 @@
 class Notification < ApplicationRecord
   has_one :child, class_name: 'Notification', foreign_key: 'notification_id'
   belongs_to :parent, class_name: 'Notification', foreign_key: 'notification_id', optional: true
+
+  # direct in the sense that provider is shared
+  def direct_parent_count
+    return 0 unless parent.present?
+
+    if provider_url == parent.provider_url
+      parent.direct_parent_count + 1
+    else
+      parent.direct_parent_count
+    end
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,2 +1,4 @@
 class Notification < ApplicationRecord
+  has_one :child, class_name: 'Notification', foreign_key: 'notification_id'
+  belongs_to :parent, class_name: 'Notification', foreign_key: 'notification_id', optional: true
 end

--- a/app/services/handle_callback_service.rb
+++ b/app/services/handle_callback_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class HandleCallbackService
+  def self.process(**args)
+    new(args).process
+  end
+
+  def initialize(external_id:, status:)
+    @external_id = external_id
+    @status = status
+  end
+
+  def process
+    notification = Notification.find_by!(external_id: @external_id)
+    notification.update!(status: @status)
+
+    return if %w[invalid delivered].include?(@status)
+    return unless @status == 'failed'
+    return if notification.direct_parent_count >= Notification::RETRY_LIMIT
+
+    RetryNotificationService.process(parent: notification)
+  end
+end

--- a/app/services/handle_notification_request_service.rb
+++ b/app/services/handle_notification_request_service.rb
@@ -25,7 +25,8 @@ class HandleNotificationRequestService
     @notification = Notification.create!(
       number: @number,
       message: @message,
-      provider_url: @provider_url
+      provider_url: @provider_url,
+      status: 'created'
     )
   end
 

--- a/app/services/queue_notification_service.rb
+++ b/app/services/queue_notification_service.rb
@@ -34,7 +34,7 @@ class QueueNotificationService
     end
 
     if @response.code == 500
-      # RetryNotificationService.process(notification: @notification)
+      RetryNotificationService.process(parent: @notification, flip_provider: true)
     end
   end
 

--- a/app/services/retry_notification_service.rb
+++ b/app/services/retry_notification_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+class RetryNotificationService
+  def self.process(**args)
+    new(args).process
+  end
+
+  def initialize(parent:, flip_provider: false)
+    @parent = parent
+    @flip_provider = flip_provider
+  end
+
+  def process
+    child = @parent.dup
+    child.provider_url = alternative_provider_url if @flip_provider
+    child.save!
+    @parent.child = child
+
+    QueueNotificationService.process(notification: child)
+  end
+
+  def alternative_provider_url
+    provider_urls = [ENV.fetch('PROVIDER_1_URL'), ENV.fetch('PROVIDER_2_URL')]
+    provider_urls.delete(@parent.provider_url)
+    provider_urls.first
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,5 @@ Rails.application.routes.draw do
     end
   end
 
-  post '/delivery_status', to: 'callbacks#text'
+  post '/delivery_status', to: 'callbacks#text_message'
 end

--- a/db/migrate/20201105023610_add_self_ref_to_notifications.rb
+++ b/db/migrate/20201105023610_add_self_ref_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddSelfRefToNotifications < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :notifications, :notification, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_01_032248) do
+ActiveRecord::Schema.define(version: 2020_11_05_023610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,10 +23,13 @@ ActiveRecord::Schema.define(version: 2020_11_01_032248) do
     t.uuid "external_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "notification_id"
     t.index ["external_id"], name: "index_notifications_on_external_id"
+    t.index ["notification_id"], name: "index_notifications_on_notification_id"
     t.index ["number"], name: "index_notifications_on_number"
     t.index ["provider_url"], name: "index_notifications_on_provider_url"
     t.index ["status"], name: "index_notifications_on_status"
   end
 
+  add_foreign_key "notifications", "notifications"
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Notification do
+  context '#direct_parent_count' do
+    it 'returns 0 if no parent' do
+      notification = FactoryBot.create(:notification, :provider_1)
+
+      expect(notification.parent).to be_nil
+      expect(notification.direct_parent_count).to eq(0)
+    end
+
+    it 'returns 1 for direct parent' do
+      notification = FactoryBot.create(:notification, :provider_1)
+      notification.child = FactoryBot.create(:notification, :provider_1)
+
+      expect(notification.child.parent).to be_present
+      expect(notification.child.direct_parent_count).to eq(1)
+    end
+
+    it 'returns 0 for indirect parent' do
+      notification = FactoryBot.create(:notification, :provider_1)
+      notification.child = FactoryBot.create(:notification, :provider_2)
+
+      expect(notification.child.parent).to be_present
+      expect(notification.child.direct_parent_count).to eq(0)
+    end
+
+    it 'returns count for and uninterrupted chain/ancestry' do
+      notification = FactoryBot.create(:notification, :provider_1)
+      notification.child = FactoryBot.create(:notification, :provider_2)
+      notification.child.child = FactoryBot.create(:notification, :provider_2)
+
+      expect(notification.child.child.parent).to be_present
+      expect(notification.child.child.direct_parent_count).to eq(1)
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Notification do
       expect(notification.child.direct_parent_count).to eq(0)
     end
 
-    it 'returns count for and uninterrupted chain/ancestry' do
+    it 'returns count for an uninterrupted chain/ancestry' do
       notification = FactoryBot.create(:notification, :provider_1, :queued)
       notification.child = FactoryBot.create(:notification, :provider_2, :queued)
       notification.child.child = FactoryBot.create(:notification, :provider_2, :queued)

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,34 +1,141 @@
 require 'rails_helper'
 
 RSpec.describe Notification do
+  context 'validations' do
+    it 'number must be present, numerical and 10 digits' do
+      expect(
+        Notification.new(
+          message: Faker::Lorem.sentence(word_count: 3, supplemental: true),
+          provider_url: Faker::Internet.url,
+          status: 'created'
+        )
+      ).to_not be_valid
+
+      expect(
+        Notification.new(
+          number: Faker::Number.number(digits: 9),
+          message: Faker::Lorem.sentence(word_count: 3, supplemental: true),
+          provider_url: Faker::Internet.url,
+          status: 'created'
+        )
+      ).to_not be_valid
+
+      expect(
+        Notification.new(
+          number: Faker::Number.number(digits: 11),
+          message: Faker::Lorem.sentence(word_count: 3, supplemental: true),
+          provider_url: Faker::Internet.url,
+          status: 'created'
+        )
+      ).to_not be_valid
+
+      expect(
+        Notification.new(
+          number: 'abcdefghij',
+          message: Faker::Lorem.sentence(word_count: 3, supplemental: true),
+          provider_url: Faker::Internet.url,
+          status: 'created'
+        )
+      ).to_not be_valid
+
+      expect(
+        Notification.new(
+          number: Faker::Number.number(digits: 10),
+          message: Faker::Lorem.sentence(word_count: 3, supplemental: true),
+          provider_url: Faker::Internet.url,
+          status: 'created'
+        )
+      ).to be_valid
+    end
+
+    it 'message must be present' do
+      expect(
+        Notification.new(
+          number: Faker::Number.number(digits: 10),
+          status: 'created'
+        )
+      ).to_not be_valid
+
+      expect(
+        Notification.new(
+          number: Faker::Number.number(digits: 10),
+          message: Faker::Lorem.sentence(word_count: 3, supplemental: true),
+          provider_url: Faker::Internet.url,
+          status: 'created'
+        )
+      ).to be_valid
+    end
+
+    it 'provider_url must be present' do
+      expect(
+        Notification.new(
+          number: Faker::Number.number(digits: 10),
+          message: Faker::Lorem.sentence(word_count: 3, supplemental: true),
+          status: 'created'
+        )
+      ).to_not be_valid
+
+      expect(
+        Notification.new(
+          number: Faker::Number.number(digits: 10),
+          message: Faker::Lorem.paragraph_by_chars(number: 256, supplemental: false),
+          provider_url: Faker::Internet.url,
+          status: 'created'
+        )
+      ).to be_valid
+    end
+
+    it 'status must be present' do
+      %w(created queued invalid delivered failed).each do |status|
+        expect(
+          Notification.new(
+            number: Faker::Number.number(digits: 10),
+            message: Faker::Lorem.sentence(word_count: 3, supplemental: true),
+            provider_url: Faker::Internet.url,
+            status: status
+          )
+        ).to be_valid
+      end
+
+      expect(
+        Notification.new(
+          number: Faker::Number.number(digits: 10),
+          message: Faker::Lorem.paragraph_by_chars(number: 256, supplemental: false),
+          provider_url: Faker::Internet.url,
+          status: 'non_existent'
+        )
+      ).to_not be_valid
+    end
+  end
+
   context '#direct_parent_count' do
     it 'returns 0 if no parent' do
-      notification = FactoryBot.create(:notification, :provider_1)
+      notification = FactoryBot.create(:notification, :provider_1, :queued)
 
       expect(notification.parent).to be_nil
       expect(notification.direct_parent_count).to eq(0)
     end
 
     it 'returns 1 for direct parent' do
-      notification = FactoryBot.create(:notification, :provider_1)
-      notification.child = FactoryBot.create(:notification, :provider_1)
+      notification = FactoryBot.create(:notification, :provider_1, :queued)
+      notification.child = FactoryBot.create(:notification, :provider_1, :queued)
 
       expect(notification.child.parent).to be_present
       expect(notification.child.direct_parent_count).to eq(1)
     end
 
     it 'returns 0 for indirect parent' do
-      notification = FactoryBot.create(:notification, :provider_1)
-      notification.child = FactoryBot.create(:notification, :provider_2)
+      notification = FactoryBot.create(:notification, :provider_1, :queued)
+      notification.child = FactoryBot.create(:notification, :provider_2, :queued)
 
       expect(notification.child.parent).to be_present
       expect(notification.child.direct_parent_count).to eq(0)
     end
 
     it 'returns count for and uninterrupted chain/ancestry' do
-      notification = FactoryBot.create(:notification, :provider_1)
-      notification.child = FactoryBot.create(:notification, :provider_2)
-      notification.child.child = FactoryBot.create(:notification, :provider_2)
+      notification = FactoryBot.create(:notification, :provider_1, :queued)
+      notification.child = FactoryBot.create(:notification, :provider_2, :queued)
+      notification.child.child = FactoryBot.create(:notification, :provider_2, :queued)
 
       expect(notification.child.child.parent).to be_present
       expect(notification.child.child.direct_parent_count).to eq(1)

--- a/spec/services/handle_callback_service_spec.rb
+++ b/spec/services/handle_callback_service_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe HandleCallbackService do
+  let(:external_id) { Faker::Internet.uuid }
+  let(:number) { Faker::Number.number(digxits: 10).to_s }
+  let(:message) { Faker::Lorem.sentence(word_count: 3, supplemental: true) }
+  let(:service) { HandleCallbackService.new(external_id: external_id, status: status) }
+  let(:provider_url) { ENV['PROVIDER_1_URL'] }
+
+  before do
+    allow(LoadBalancerService).to receive(:process).and_return(provider_url)
+    allow(QueueNotificationService).to receive(:process).and_return(true)
+  end
+
+  context '#initialize' do
+    it 'expects external_id and status parameters' do
+      FactoryBot.create(:notification, :provider_1, :queued, external_id: external_id)
+
+      expect { HandleCallbackService.process }.to raise_error(ArgumentError)
+
+      expect {
+        HandleCallbackService.process(external_id: external_id, status: 'delivered')
+      }.to_not raise_error
+    end
+  end
+
+  context '#process' do
+    it 'finds the notification based on the external_id and updates status' do
+      notification = FactoryBot.create(:notification, :provider_1, :queued, external_id: external_id)
+
+      expect(Notification).to receive(:find_by!).with(external_id: external_id).and_return(notification)
+      expect(notification).to receive(:update!)
+
+      HandleCallbackService.process(external_id: external_id, status: 'delivered')
+    end
+
+    it 'raises an exception if notification not found' do
+      expect {
+        HandleCallbackService.process(external_id: external_id, status: 'delivered')
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'raises an exception if status is not supported' do
+      FactoryBot.create(:notification, :provider_1, :queued, external_id: external_id)
+
+      expect {
+        HandleCallbackService.process(external_id: external_id, status: 'unknown')
+      }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Status is not included in the list')
+    end
+
+    it 'does not retry if status is invalid or delivered' do
+      FactoryBot.create(:notification, :provider_1, :queued, external_id: external_id)
+
+      expect(RetryNotificationService).to_not receive(:process)
+
+      HandleCallbackService.process(external_id: external_id, status: %w[delivered invalid].sample)
+    end
+
+    it 'retries if status is failed' do
+      FactoryBot.create(:notification, :provider_1, :queued, external_id: external_id)
+
+      expect(RetryNotificationService).to receive(:process)
+
+      HandleCallbackService.process(external_id: external_id, status: 'failed')
+    end
+  end
+
+  context 'retry limit' do
+    it 'keeps retrying up to 3 generations' do
+      notification_1 = FactoryBot.create(:notification, :provider_1, status: 'failed', external_id: Faker::Internet.uuid)
+
+      external_id = Faker::Internet.uuid
+      notification_1.child = FactoryBot.create(:notification, :provider_1, :queued, external_id: external_id)
+
+      expect(RetryNotificationService).to receive(:process)
+
+      HandleCallbackService.process(external_id: external_id, status: 'failed')
+    end
+
+    it 'stops retrying after 3 generations' do
+      notification_1 = FactoryBot.create(:notification, :provider_1, status: 'failed', external_id: Faker::Internet.uuid)
+      notification_2 = FactoryBot.create(:notification, :provider_1, status: 'failed', external_id: Faker::Internet.uuid)
+      notification_1.child = notification_2
+
+      external_id = Faker::Internet.uuid
+      notification_2.child = FactoryBot.create(:notification, :provider_1, status: 'failed', external_id: external_id)
+
+      expect(RetryNotificationService).to_not receive(:process)
+
+      HandleCallbackService.process(external_id: external_id, status: 'failed')
+    end
+  end
+end

--- a/spec/services/handle_notification_request_service_spec.rb
+++ b/spec/services/handle_notification_request_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe HandleNotificationRequestService do
   context '#create_notification' do
     it 'creates a record' do
       notification = double('notification',
-        :persisted? => true,
+        persisted?: true,
         number: number,
         message: message,
         provider_url: provider_url
@@ -39,7 +39,8 @@ RSpec.describe HandleNotificationRequestService do
       expect(Notification).to receive(:create!).with(
         number: number,
         message: message,
-        provider_url: provider_url
+        provider_url: provider_url,
+        status: 'created'
       ).and_return(notification)
 
       service.process

--- a/spec/services/queue_notification_service_spec.rb
+++ b/spec/services/queue_notification_service_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe QueueNotificationService do
         body: { 'error': 'Something went wrong' }.to_json
       )
 
-      # expect(RetryNotificationService).to receive(:process).with(notification: notification)
+      expect(RetryNotificationService).to receive(:process)
+        .with(parent: notification, flip_provider: true)
 
       service.process(notification: notification)
 

--- a/spec/services/retry_notification_service_spec.rb
+++ b/spec/services/retry_notification_service_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe RetryNotificationService do
+  let(:service) { RetryNotificationService }
+  let(:notification) { FactoryBot.create(:notification, :queued, :provider_1) }
+
+  before do
+    allow(QueueNotificationService).to receive(:process).and_return(true)
+  end
+
+  context '#initialize' do
+    it 'expects parent parameter' do
+      expect { service.process }.to raise_error(ArgumentError)
+      expect { service.process(parent: notification) }.to_not raise_error
+    end
+  end
+
+  context 'with flipped provider' do
+    it 'creates and queues child notification' do
+      expect(QueueNotificationService).to receive(:process)
+
+      service.process(parent: notification, flip_provider: true)
+
+      expect(notification.status).to eq(notification.child.status)
+      expect(notification.message).to eq(notification.child.message)
+      expect(notification.child.parent).to match(notification)
+      expect(notification.provider_url).to_not eq(notification.child.provider_url)
+    end
+  end
+
+  context 'with the same provider' do
+    it 'creates and queues child notification' do
+      expect(QueueNotificationService).to receive(:process)
+
+      service.process(parent: notification)
+
+      expect(notification.status).to eq(notification.child.status)
+      expect(notification.message).to eq(notification.child.message)
+      expect(notification.child.parent).to match(notification)
+      expect(notification.provider_url).to eq(notification.child.provider_url)
+    end
+  end
+
+  context '#alternative_provider_url' do
+    it 'returns the other provider\'s url' do
+      notification_1 = FactoryBot.create(:notification, :queued, :provider_1)
+      notification_2 = FactoryBot.create(:notification, :queued, :provider_2)
+
+      service = RetryNotificationService.new(parent: notification_1, flip_provider: true)
+
+      expect(service.alternative_provider_url).to eq(ENV.fetch('PROVIDER_2_URL'))
+
+      service = RetryNotificationService.new(parent: notification_2, flip_provider: true)
+
+      expect(service.alternative_provider_url).to eq(ENV.fetch('PROVIDER_1_URL'))
+    end
+  end
+end


### PR DESCRIPTION
This PR: 
* Implements self-referential association for the notification model to enable parent-child hierarchy
* Adds `RetryNotificationService` to handle both retry scenarios: (1) a provider fails and the notification is queued on the other provider, (2) notifications are retried on the same provider
* Builds out notification model validations
* Adds a mechanism to control the number of notification retries and limits those retries
* Builds the notification status logic/sequence across the app
* Adds the callback logic and encapsulates it in `HandleCallbackService`